### PR TITLE
fix version getting in setup.py & bump to version 0.0.5

### DIFF
--- a/decorest/__init__.py
+++ b/decorest/__init__.py
@@ -32,6 +32,5 @@ __all__ = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS',
            'query', 'body', 'header', 'on', 'accept', 'content',
            'endpoint', 'timeout', 'stream', 'form']
 
-__version__ = (0, 0, 4)
+__version__ = "0.0.5"
 
-decorest_version = '.'.join(map(str, __version__))

--- a/decorest/__init__.py
+++ b/decorest/__init__.py
@@ -33,4 +33,3 @@ __all__ = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS',
            'endpoint', 'timeout', 'stream', 'form']
 
 __version__ = "0.0.5"
-

--- a/examples/httpbin/httpbin_client.py
+++ b/examples/httpbin/httpbin_client.py
@@ -25,7 +25,7 @@ import brotli
 
 from decorest import DELETE, GET, PATCH, POST, PUT
 from decorest import HttpStatus, RestClient
-from decorest import accept, body, content, decorest_version, endpoint, form
+from decorest import accept, body, content, __version__, endpoint, form
 from decorest import header, on, query, stream, timeout
 
 
@@ -49,7 +49,7 @@ def parse_image(response):
     return None
 
 
-@header('user-agent', 'decorest/{v}'.format(v=decorest_version))
+@header('user-agent', 'decorest/{v}'.format(v=__version__))
 @accept('application/json')
 @endpoint('http://httpbin.org')
 class HttpBinClient(RestClient):

--- a/examples/httpbin/httpbin_client.py
+++ b/examples/httpbin/httpbin_client.py
@@ -25,7 +25,7 @@ import brotli
 
 from decorest import DELETE, GET, PATCH, POST, PUT
 from decorest import HttpStatus, RestClient
-from decorest import accept, body, content, __version__, endpoint, form
+from decorest import __version__, accept, body, content, endpoint, form
 from decorest import header, on, query, stream, timeout
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ from setuptools import find_packages, setup
 
 
 def get_version():
-    """
-    Return package version as listed in `__version__` in `init.py`.
-    """
+    """Return package version as listed in `__version__` in `init.py`."""
     init_py = open('decorest/__init__.py').read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,20 @@
 
 
 import os
-
-from decorest import __version__
+import re
 
 from setuptools import find_packages, setup
+
+
+def get_version():
+    """
+    Return package version as listed in `__version__` in `init.py`.
+    """
+    init_py = open('decorest/__init__.py').read()
+    return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
+
+
+version = get_version()
 
 
 def read(fname):
@@ -32,7 +42,7 @@ requirements = []
 
 setup(
     name="decorest",
-    version=".".join(map(str, __version__)),
+    version=version,
     description="`decorest` library provides an easy to use declarative "
     "REST API client interface, where definition of the API methods using "
     "decorators automatically gives a working REST client with no "

--- a/tests/httpbin_test.py
+++ b/tests/httpbin_test.py
@@ -19,7 +19,7 @@ import time
 import os
 import sys
 import json
-from decorest import decorest_version, HttpStatus
+from decorest import __version__, HttpStatus
 from requests import cookies
 from requests.exceptions import ReadTimeout, HTTPError
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -77,7 +77,7 @@ def test_user_agent(client):
     """
     res = client.user_agent()
 
-    assert res['user-agent'] == 'decorest/{v}'.format(v=decorest_version)
+    assert res['user-agent'] == 'decorest/{v}'.format(v=__version__)
 
 
 def test_headers(client):
@@ -86,7 +86,7 @@ def test_headers(client):
     res = client.headers(header={'A': 'AA', 'B': 'CC'})
 
     assert res['headers']['User-Agent'] == 'decorest/{v}'.format(
-        v=decorest_version)
+        v=__version__)
     assert res['headers']['A'] == 'AA'
     assert res['headers']['B'] == 'CC'
 


### PR DESCRIPTION
Current code has a bug which forbids to install decorest package if requests are not already installed. During package install setup.py file is importing version from decorest/__init__.py which importsa lot of modules from the package, some of them requires requests and try to import it. This was causing import error at decorest package installation if requests is not already installed.

```
Collecting six (from -r client/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
Collecting requests (from -r client/requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/65/47/7e02164a2a3db50ed6d8a6ab1d6d60b69c4c3fdf57a284257925dfc12bda/requests-2.19.1-py2.py3-none-any.whl
Collecting decorest (from -r client/requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/13/ac/07dfd314a33f2b892b3a53d3b71f8ce11c64e8992d92a1ac786279c9c084/decorest-0.0.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-asphgqsf/decorest/setup.py", line 21, in <module>
        from decorest import __version__
      File "/tmp/pip-install-asphgqsf/decorest/decorest/__init__.py", line 18, in <module>
        from .DELETE import DELETE
      File "/tmp/pip-install-asphgqsf/decorest/decorest/DELETE.py", line 20, in <module>
        from .decorators import HttpMethodDecorator, set_decor
      File "/tmp/pip-install-asphgqsf/decorest/decorest/decorators.py", line 28, in <module>
        import requests
    ModuleNotFoundError: No module named 'requests'
```

requirements.txt has three packages listed: six, requests and decorest (without version, in this order)

Here is proposed fix which reads __init__.py file and grab version using simple regex. Such solution is used in many python packages (eg django-restframework).

If you merge this PR, please upload pip package, because currently only version 0.0.3 available.