### PR TITLE
Fix merge_dicts() empty case

### DIFF
--- a/decorest/utils.py
+++ b/decorest/utils.py
@@ -84,6 +84,8 @@ def merge_dicts(*dict_args):
                 result = dictionary
             else:
                 result.update(dictionary)
+    if result is None:
+      result = {}
     return result
 
 


### PR DESCRIPTION
Without this fix, merge_dicts() may return a `None` instead of a dict.