### PR TITLE
Remove `None` valued params from httpx request

### DIFF
--- a/decorest/request.py
+++ b/decorest/request.py
@@ -304,10 +304,18 @@ class HttpRequest:
         Translates and converts argument names and values from
         requests to httpx, e.g.
             'allow_redirects' -> 'follow_redirects'
+
+        Removes None valued entries from params as requests hides them
+        but httpx treats them as empty valued.
         """
         if 'allow_redirects' in kwargs:
             kwargs['follow_redirects'] = kwargs['allow_redirects']
             del kwargs['allow_redirects']
+        if 'params' in kwargs:
+            kwargs['params'] = {
+                k: v
+                for k, v in kwargs['params'].items() if v is not None
+            }
 
     def _normalize_for_requests(self, kwargs: ArgsDict) -> None:
         """

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,7 @@ docker =
 deps =
     pytest
     pytest-cov
-    pytest-asyncio
+    pytest-asyncio==0.16.0
     requests
     requests-toolbelt
     typing-extensions


### PR DESCRIPTION
Hello,

thank you for your project. I have noticed a minor inconsistency with the backends.

If I want to have an optional parameter/query that is hidden when not in use I can set it to `None` and requests will not append it. Unfortunately httpx keeps them appended as `?optional_parameter=`. An API that I use doesn't support this behavior.

Example
``` python
@GET('/inventory')
@query('optional_parameter')
def get_inventory(self, optional_parameter=None):
    pass
```

With `backend='requests'` this would result in `http://example.com/inventory`
With `backend='httpx'` this would result in `http://example.com/inventory?optional_parameter=`

This is because the requests module treats `None` valued parameters as not existing and doesn't transmit them, whereas httpx treats them as empty valued. Therefore, we remove them manually in the translation.

I hope the fix is up to your standards :)

Greetings
Markus