### PR TITLE
Add ability to use `kwargs` for use with decorator

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/decorest/request.py
+++ b/decorest/request.py
@@ -72,7 +72,7 @@ class HttpRequest:
         self.rest_client = args[0]
 
         args_dict = dict_from_args(func, *args)
-        self.req_path = render_path(self.path_template, args_dict)
+        self.req_path = render_path(self.path_template, args_dict, kwargs)
         self.session = None
         if '__session' in self.kwargs:
             self.session = self.kwargs['__session']
@@ -400,7 +400,7 @@ class HttpRequest:
                         parameters[value] = kwargs[arg]
                         # Delete from kwargs so that we don't
                         # pass them on to requests/httpx
-                        del (kwargs[arg])
+                        del kwargs[arg]
                 else:
                     parameters[arg] = value
         return parameters

--- a/tests/petstore_test.py
+++ b/tests/petstore_test.py
@@ -161,3 +161,49 @@ def test_user_methods(client):
 
     with pytest.raises(HTTPErrorWrapper) as e:
         client.get_user('swagger')
+
+
+@pytest.mark.parametrize("client", pytest_params)
+def test_user_methods_with_kwargs_params(client):
+
+    res = client.create_user({
+        'username': 'swagger',
+        'firstName': 'Swagger',
+        'lastName': 'Petstore',
+        'email': 'swagger@example.com',
+        'password': 'guess',
+        'phone': '001-111-CALL-ME',
+        "userStatus": 0
+    })
+
+    assert res is True
+
+    # Mixed usage
+    res = client.login('swagger', password='petstore')
+
+    assert res.decode("utf-8").startswith('logged in user session:')
+
+    res = client.get_user(username='swagger')
+
+    assert res['phone'] == '001-111-CALL-ME'
+
+    client.update_user(
+        'swagger', {
+            'username': 'swagger',
+            'firstName': 'Swagger',
+            'lastName': 'Petstore',
+            'email': 'swagger@example.com',
+            'password': 'guess',
+            'phone': '001-111-CALL-ME',
+            "userStatus": 0
+        })
+
+    res = client.get_user(username='swagger')
+
+    assert res['email'] == 'swagger@example.com'
+    assert res['password'] == 'guess'
+
+    client.delete_user(username='swagger')
+
+    with pytest.raises(HTTPErrorWrapper) as e:
+        client.get_user(username='swagger')

--- a/tests/petstore_test_with_typing.py
+++ b/tests/petstore_test_with_typing.py
@@ -151,3 +151,45 @@ def test_user_methods(client: PetstoreClientWithTyping) -> None:
     assert res['password'] == 'guess'
 
     client.delete_user('swagger')
+
+
+def test_user_methods_with_kwargs_params(
+        client: PetstoreClientWithTyping) -> None:
+
+    res = client.create_user({
+        'username': 'swagger',
+        'firstName': 'Swagger',
+        'lastName': 'Petstore',
+        'email': 'swagger@example.com',
+        'password': 'guess',
+        'phone': '001-111-CALL-ME',
+        "userStatus": 0
+    })
+
+    assert res is True
+
+    res = client.login('swagger', password='petstore')
+
+    assert res.decode("utf-8").startswith('logged in user session:')
+
+    res = client.get_user(username='swagger')
+
+    assert res['phone'] == '001-111-CALL-ME'
+
+    client.update_user(
+        123, {
+            'username': 'swagger',
+            'firstName': 'Swagger',
+            'lastName': 'Petstore',
+            'email': 'swagger@example.com',
+            'password': 'guess',
+            'phone': '001-111-CALL-ME',
+            "userStatus": 0
+        })
+
+    res = client.get_user(username='swagger')
+
+    assert res['email'] == 'swagger@example.com'
+    assert res['password'] == 'guess'
+
+    client.delete_user(username='swagger')


### PR DESCRIPTION
Hello @bkryza 

I have noticed that I'm unable to use keyword args for the decorators. I hope the examples provide an insight in what I want to achieve.

``` python
@GET('/users')
@query('search')
@query('limit')
def search_user(search, limit=10):
    pass
```

Ordered Parameters: works
``` python
client.search_user('123', 20)
```

I think this is one/the "decorest" way: works
``` python
client.search_user('123', query={'limit': 20})
```

But I would like to use keyword arguments: doesn't work
``` python
client.search_user('123', limit=20)
# or
client.search_user(search='123', limit=20)
```

I have submitted a possible fix for it. But I would consider it more of a workaround, as it manipulates a pass by reference array (kwargs). But I have submitted it anyway as a point to start a discussion.

Additionally I would like to add some test cases. Where should I put them?

Thanks
Markus

- Use both `args_dict` and `kwargs` for `_merge_args(...)`
- Remove 'used' kwargs so that they don't collide with httpx/requests
